### PR TITLE
Borisko/ops agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk as base
 
 RUN apt-get update && apt-get install git bash curl python3 software-properties-common wget ca-certificates zip -y
 
@@ -16,6 +16,18 @@ RUN wget -q https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraf
 ##########################################################################################
 RUN apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/{apt,dpkg,cache,log}/
 
+FROM base as test
+WORKDIR /test
+RUN apt-get update \
+    && apt-get install -y bc \
+    && apt-get clean autoclean \
+    && apt-get autoremove --yes \
+    && rm -rf /var/lib/{apt,dpkg,cache,log}/
+COPY aiinfra-cluster/installation_scripts/ /test
+RUN chmod +x /test/run_tests.sh
+ENTRYPOINT ["./run_tests.sh"]
+
+FROM base as deploy
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 COPY aiinfra-cluster/ /usr/primary/
 COPY scripts/ /usr/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ The optional parameters are:
     -  __default_network__: MIG uses the default VPC in the project.
     -  __new_network__: A new VPC is created for the MIG.
     -  __multi_nic_network__: New VPCs are created and used by all the VMs in the MIG. By default 5 new VPCs are created and 5 NICs are used for the MIG but that value is configurable.
+20. ***ON_INSTALL_OPS_AGENT_FAILURE***. Can be one of:
+    - `terminate` (default): Install Ops Agent and terminate provisioning if unsuccessful.
+    - `continue` (default): Install Ops Agent and continue provisioning if unsuccessful.
 
 
 The user needs to provide value for the above mandatory parameters. All other parameters are optional and default behaviour is described above. Users can also enable/disable various features using feature flags in the config, for example: ORCHESTRATOR_TYPE, SHOW_PROXY_URL, GCSFuse, Multi-NIC VM etc. The configuration file contains configs as key value pairs and provided to the ‘docker run’ command. These are set as environment variables within the docker container and then entrypoint.sh script uses these environment variables to configure terraform to create resources accordingly. 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ The optional parameters are:
     -  __default_network__: MIG uses the default VPC in the project.
     -  __new_network__: A new VPC is created for the MIG.
     -  __multi_nic_network__: New VPCs are created and used by all the VMs in the MIG. By default 5 new VPCs are created and 5 NICs are used for the MIG but that value is configurable.
-20. ***ON_INSTALL_OPS_AGENT_FAILURE***. Can be one of:
-    - `terminate` (default): Install Ops Agent and terminate provisioning if unsuccessful.
-    - `continue` (default): Install Ops Agent and continue provisioning if unsuccessful.
+20. ***DISABLE_OPS_AGENT***. Can be one of:
+    - `false` (default): Install Ops Agent with random-backoff retries
+    - `true`: Do not install Ops Agent
 
 
 The user needs to provide value for the above mandatory parameters. All other parameters are optional and default behaviour is described above. Users can also enable/disable various features using feature flags in the config, for example: ORCHESTRATOR_TYPE, SHOW_PROXY_URL, GCSFuse, Multi-NIC VM etc. The configuration file contains configs as key value pairs and provided to the ‘docker run’ command. These are set as environment variables within the docker container and then entrypoint.sh script uses these environment variables to configure terraform to create resources accordingly. 

--- a/aiinfra-cluster/installation_scripts/install_cloud_ops_agent.sh
+++ b/aiinfra-cluster/installation_scripts/install_cloud_ops_agent.sh
@@ -143,7 +143,6 @@ handle_debian() {
     install_dcgm() {
         echo 'nvidia-uvm' >>/etc/modules
 
-        # TODO: move to GCS
         cat >/etc/google-cloud-ops-agent/config.yaml <<EOF
 metrics:
   receivers:
@@ -162,7 +161,6 @@ metrics:
         receivers:
           - dcgm
 EOF
-        systemctl restart google-cloud-ops-agent
 
         local distribution=$(. /etc/os-release;echo $ID$VERSION_ID | sed -e 's/\.//g')
         echo "Installing DCGM for distribution '${distribution}'"
@@ -173,6 +171,7 @@ EOF
 
         sed -i '/\[Service\]/a RestartSec=2' /lib/systemd/system/nvidia-dcgm.service
         systemctl start nvidia-dcgm
+        systemctl restart google-cloud-ops-agent
     }
 }
 

--- a/aiinfra-cluster/installation_scripts/install_cloud_ops_agent.sh
+++ b/aiinfra-cluster/installation_scripts/install_cloud_ops_agent.sh
@@ -19,8 +19,7 @@ OPSAGENT_PACKAGE='google-cloud-ops-agent'
 
 fail() {
     echo >&2 "[$(date +'%Y-%m-%dT%H:%M:%S%z')] $*"
-    [ "${ON_INSTALL_OPS_AGENT_FAILURE}" == "continue" ]
-    exit $?
+    exit 1
 }
 
 # starting with `b^0==1` and ending with `b^(n-1)==y`,

--- a/aiinfra-cluster/installation_scripts/install_cloud_ops_agent_tests.sh
+++ b/aiinfra-cluster/installation_scripts/install_cloud_ops_agent_tests.sh
@@ -1,0 +1,67 @@
+. <(grep -v '^main$' ./install_cloud_ops_agent.sh)
+
+# gen_exponential
+
+test::gen_exponential::fails_on_n_eq_one_y_ne_one () {
+    EXPECT_FAIL gen_exponential 1 2
+}
+
+test::gen_exponential::gens_powers_of_two () {
+    local expected output
+    declare -a expected=(1.0 2.0 4.0 8.0)
+    declare -a output=($(gen_exponential 4 8))
+    EXPECT_ARREQ expected output
+}
+
+# gen_backoff_times
+
+test::gen_backoff_times::gens_nothing_when_count_eq_zero () {
+    EXPECT_SUCCEED [ -z "$(gen_backoff_times 0 8)" ]
+}
+
+test::gen_backoff_times::gens_under_max_when_count_eq_one () {
+    local t=8 output
+    declare -a output=($(gen_backoff_times 1 ${t}))
+    EXPECT_SUCCEED [ "${#output[@]}" -eq 1 ]
+    EXPECT_SUCCEED [ $(echo "0 <= ${output[0]}" | bc -l) -eq 1 ]
+    EXPECT_SUCCEED [ $(echo "${output[0]} <= ${t}" | bc -l) -eq 1 ]
+}
+
+test::gen_backoff_times::gens_under_exponential_when_count_gt_one () {
+    local n=4 t=8 output maximums
+    declare -a output=($(gen_backoff_times ${n} ${t}))
+    declare -a maximums=($(gen_exponential ${n} ${t}))
+    EXPECT_SUCCEED [ "${#output[@]}" -eq ${n} ]
+    for i in $(seq 0 "$((n - 1))"); do
+        EXPECT_SUCCEED [ $(echo "0 <= ${output[$i]}" | bc -l) -eq 1 ]
+        EXPECT_SUCCEED [ $(echo "${output[$i]} <= ${t}" | bc -l) -eq 1 ]
+    done
+}
+
+# retry_with_backoff
+
+decrement_counter_to_zero () {
+    [ "$((--counter))" -le 0 ]
+}
+
+test::retry_with_backoff::passes_when_one_attempt_given_and_one_needed () {
+    local counter=1
+    EXPECT_SUCCEED retry_with_backoff 1 1 decrement_counter_to_zero
+}
+
+test::retry_with_backoff::fails_when_one_attempt_given_and_two_needed () {
+    local counter=2
+    EXPECT_FAIL retry_with_backoff 1 1 decrement_counter_to_zero
+    EXPECT_SUCCEED [ "${counter}" -eq 1 ]
+}
+
+test::retry_with_backoff::passes_when_less_attempts_needed_than_given () {
+    local counter=3
+    EXPECT_SUCCEED retry_with_backoff 4 1 decrement_counter_to_zero
+}
+
+test::retry_with_backoff::fails_when_more_attempts_needed_than_given () {
+    local counter=3
+    EXPECT_FAIL retry_with_backoff 2 1 decrement_counter_to_zero
+    EXPECT_SUCCEED [ "${counter}" -eq 1 ]
+}

--- a/aiinfra-cluster/installation_scripts/install_cloud_ops_agent_tests.sh
+++ b/aiinfra-cluster/installation_scripts/install_cloud_ops_agent_tests.sh
@@ -40,28 +40,29 @@ test::gen_backoff_times::gens_under_exponential_when_count_gt_one () {
 
 # retry_with_backoff
 
-decrement_counter_to_zero () {
-    [ "$((--counter))" -le 0 ]
+decrement_to_zero () {
+    local var_name="${1}"
+    [ "$((--${var_name}))" -le 0 ]
 }
 
 test::retry_with_backoff::passes_when_one_attempt_given_and_one_needed () {
-    local counter=1
-    EXPECT_SUCCEED retry_with_backoff 1 1 decrement_counter_to_zero
+    counter=1
+    EXPECT_SUCCEED retry_with_backoff 1 1 decrement_to_zero counter
 }
 
 test::retry_with_backoff::fails_when_one_attempt_given_and_two_needed () {
     local counter=2
-    EXPECT_FAIL retry_with_backoff 1 1 decrement_counter_to_zero
+    EXPECT_FAIL retry_with_backoff 1 1 decrement_to_zero counter
     EXPECT_SUCCEED [ "${counter}" -eq 1 ]
 }
 
 test::retry_with_backoff::passes_when_less_attempts_needed_than_given () {
     local counter=3
-    EXPECT_SUCCEED retry_with_backoff 4 1 decrement_counter_to_zero
+    EXPECT_SUCCEED retry_with_backoff 4 1 decrement_to_zero counter
 }
 
 test::retry_with_backoff::fails_when_more_attempts_needed_than_given () {
     local counter=3
-    EXPECT_FAIL retry_with_backoff 2 1 decrement_counter_to_zero
+    EXPECT_FAIL retry_with_backoff 2 1 decrement_to_zero counter
     EXPECT_SUCCEED [ "${counter}" -eq 1 ]
 }

--- a/aiinfra-cluster/installation_scripts/run_tests.sh
+++ b/aiinfra-cluster/installation_scripts/run_tests.sh
@@ -1,0 +1,84 @@
+declare -a TEST_FILES=(
+    ./install_cloud_ops_agent_tests.sh)
+
+err_prefix () {
+    local fn_name="${1}"
+    local params
+
+    declare -a params=("${@:2}")
+    local params_str=""
+
+    if [ "${#params[@]}" -ge 1 ]; then
+        params_str="'${params[0]}'"
+    fi
+
+    local i
+    for i in $(seq 1 $((${#params[@]} - 1))); do
+        params_str="${params_str}, '${params[$i]}'"
+    done
+
+    echo "--> ${fn_name}(${params_str}):"
+}
+
+EXPECT_SUCCEED () {
+    if ! "${@}" >/dev/null; then
+        echo >&2 $(err_prefix EXPECT_SUCCEED "${*}") "failed"
+        exit 1
+    fi
+    return 0
+}
+
+EXPECT_FAIL () {
+    if "${@}" 2>/dev/null; then
+        echo >&2 $(err_prefix EXPECT_FAIL "${*}") "succeeded"
+        exit 1
+    fi
+    return 0
+}
+
+EXPECT_ARREQ () {
+    local left_name="${1}"
+    local right_name="${2}"
+    local -n left="${left_name}"
+    local -n right="${right_name}"
+    local err_prefix=$(err_prefix EXPECT_ARREQ "${left_name}" "${right_name}")
+
+    if [ "${#left[@]}" -ne "${#right[@]}" ]; then
+        echo >&2 "${err_prefix}" "unequal lengths (${#left[@]}, ${#right[@]})"
+        exit 1
+    fi
+
+    local arr_length="${#left[@]}"
+    local i
+    for i in $(seq 0 $((arr_length - 1))); do
+        if [ "${left[$i]}" != "${right[$i]}" ]; then
+            echo >&2 "${err_prefix}" "unequal elements [$i] (${left[$i]}, ${right[$i]})"
+            exit 1
+        fi
+    done
+
+    return 0
+}
+
+run_tests () {
+    local COLOR_GRN='\e[1;32m'
+    local COLOR_RED='\e[0;31m'
+    local COLOR_RST='\e[0m'
+    local failure=false
+    local test_command
+
+    while read test_command; do
+        if (${test_command} >/dev/null); then
+            echo -e "${test_command} ${COLOR_GRN}succeeded${COLOR_RST}"
+        else
+            echo -e "${test_command} ${COLOR_RED}failed${COLOR_RST}"
+            failure=true
+        fi
+    done < <(declare -F | awk '/test::/{print $NF}')
+
+    [ "${failure}" == false ]
+}
+
+. <(cat "${TEST_FILES[@]}")
+
+run_tests

--- a/aiinfra-cluster/installation_scripts/run_tests.sh
+++ b/aiinfra-cluster/installation_scripts/run_tests.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 declare -a TEST_FILES=(
     ./install_cloud_ops_agent_tests.sh)
 

--- a/aiinfra-cluster/main.tf
+++ b/aiinfra-cluster/main.tf
@@ -89,7 +89,7 @@ module "nfs_filestore" {
 module "startup" {
   source          = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script/?ref=1b1cdb09347433ecdb65488989f70135e65e217b"
   project_id      = var.project_id
-  runners = concat([{
+  runners = concat(var.disable_ops_agent ? [] : [{
     destination = "install_cloud_ops_agent.sh"
     source      = "${path.module}/installation_scripts/install_cloud_ops_agent.sh"
     type        = "shell"

--- a/aiinfra-cluster/main.tf
+++ b/aiinfra-cluster/main.tf
@@ -55,7 +55,7 @@ locals {
     }
   ] : []
   
-  vm_startup_setup      = concat(local.ray_setup, local.startup_command_setup, local.install_ops_agent)
+  vm_startup_setup      = concat(local.ray_setup, local.install_ops_agent, local.startup_command_setup)
 
 }
 

--- a/aiinfra-cluster/modules/dashboard/outputs.tf
+++ b/aiinfra-cluster/modules/dashboard/outputs.tf
@@ -1,0 +1,446 @@
+/**
+  * Copyright 2022 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+// reference:
+// https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/tree/master/dashboards/nvidia-gpu
+
+output "widget_objects" {
+  description = ""
+  value = [
+    {
+      timeSeriesTable = {
+        dataSets = [
+          {
+            timeSeriesQuery = {
+              timeSeriesQueryLanguage = <<EOF
+                fetch gce_instance
+                | metric 'agent.googleapis.com/gpu/utilization'
+                | map [Model: metric.model, UUID: metric.uuid, Instance: metadata.system.name, GPU: metric.gpu_number]
+                | value cast_units(int_round(value.utilization), "%")
+                EOF
+            }
+          },
+        ]
+        metricVisualization = "NUMBER"
+      }
+      title = "Observed GPU utilization per GPU (NVML reported)"
+    },
+    {
+      timeSeriesTable = {
+        dataSets = [
+          {
+            timeSeriesQuery = {
+              timeSeriesQueryLanguage = <<EOF
+                fetch gce_instance
+                | metric 'agent.googleapis.com/gpu/utilization'
+                | map [Model: metric.model, Instance: metadata.system.name, GPU: metric.gpu_number]
+                | value [value.utilization: 1.0]
+                | group_by [Model], [capacity: sum(value.utilization)]
+                EOF
+            }
+          }
+        ],
+        metricVisualization = "NUMBER"
+      },
+      title = "Observed GPU Capacity"
+    },
+    {
+      timeSeriesTable = {
+        dataSets = [
+          {
+            timeSeriesQuery = {
+              timeSeriesQueryLanguage = <<EOF
+                fetch gce_instance
+                | metric 'agent.googleapis.com/gpu/utilization'
+                | map [Model: metric.model, Instance: metadata.system.name, GPU: metric.gpu_number]
+                | group_by [Model], [capacity: sum(cast_units(value.utilization/100.0, "1"))]
+                EOF
+            }
+          }
+        ],
+        metricVisualization = "NUMBER"
+      },
+      title = "Observed GPU Utilization (NVML reported)"
+    },
+    {
+      timeSeriesTable = {
+        columnSettings = [
+          {
+            column = "Name (from instance_id)",
+            visible = true
+          },
+          {
+            column = "zone",
+            visible = true
+          },
+          {
+            column = "instance_name",
+            visible = true
+          }
+        ],
+        dataSets = [
+          {
+            timeSeriesQuery = {
+              timeSeriesQueryLanguage = <<EOF
+                fetch gce_instance
+                | metric 'agent.googleapis.com/gpu/processes/utilization'
+                | map [Instance: metadata.system.name,
+                    GPU: metric.gpu_number,
+                    PID: metric.pid,
+                    Owner: metric.owner,
+                    Command: metric.command_line], 
+                | value cast_units(int_round(value.utilization), "%")
+                EOF
+            }
+          }
+        ],
+        metricVisualization = "NUMBER"
+      },
+      title = "Recently Observed GPU Processes - Lifetime GPU Utilization (NVML reported)"
+    },
+    {
+      timeSeriesTable = {
+        dataSets = [
+          {
+            timeSeriesQuery = {
+              timeSeriesQueryLanguage = <<EOF
+                fetch gce_instance
+                | metric 'agent.googleapis.com/gpu/processes/max_bytes_used'
+                | map [Instance: metadata.system.name,
+                    GPU: metric.gpu_number,
+                    PID: metric.pid,
+                    Owner: metric.owner,
+                    Command: metric.command_line]
+                EOF
+            }
+          }
+        ],
+        metricVisualization = "NUMBER"
+      },
+      title = "Recently Observed GPU Processes - Lifetime Max GPU Memory Used (NVML reported)"
+    },
+    {
+      title = "CPU Utilization (Hypervisor Reported)",
+      xyChart = {
+        chartOptions = {
+          mode = "COLOR"
+        },
+        dataSets = [
+          {
+            plotType = "LINE",
+            targetAxis = "Y1",
+            timeSeriesQuery = {
+              timeSeriesQueryLanguage = <<EOF
+                fetch gce_instance
+                | metric 'compute.googleapis.com/instance/cpu/utilization'
+                | group_by 1m, [value_utilization_mean: mean(value.utilization)]
+                | every 1m
+                | group_by [metadata.system.name: metadata.system_labels.name],
+                    [value_utilization_mean_mean: mean(value_utilization_mean)]
+                EOF
+            }
+          }
+        ],
+        thresholds = [],
+        timeshiftDuration = "0s",
+        yAxis = {
+          label = "y1Axis",
+          scale = "LINEAR"
+        }
+      }
+    },
+    {
+      title = "NIC Traffic Rate (OS reported)",
+      xyChart = {
+        chartOptions = {
+          mode = "COLOR"
+        },
+        dataSets = [
+          {
+            legendTemplate = "$${metadata.system_labels\\.name} Device $${metric.labels.device} Direction $${metric.labels.direction} NIC ",
+            minAlignmentPeriod = "60s",
+            plotType = "LINE",
+            targetAxis = "Y1",
+            timeSeriesQuery = {
+              apiSource = "DEFAULT_CLOUD",
+              timeSeriesFilter = {
+                aggregation = {
+                  alignmentPeriod = "60s",
+                  crossSeriesReducer = "REDUCE_NONE",
+                  perSeriesAligner = "ALIGN_RATE"
+                },
+                filter = "metric.type=\"agent.googleapis.com/interface/traffic\" resource.type=\"gce_instance\" metric.label.\"device\"!=\"lo\" metric.label.\"device\"!=\"docker0\"",
+                secondaryAggregation = {
+                  alignmentPeriod = "60s",
+                  crossSeriesReducer = "REDUCE_SUM",
+                  groupByFields = [
+                    "metric.label.\"device\"",
+                    "metric.label.\"direction\"",
+                    "metadata.system_labels.\"name\""
+                  ],
+                  perSeriesAligner = "ALIGN_NONE"
+                }
+              }
+            }
+          }
+        ],
+        thresholds = [],
+        timeshiftDuration = "0s",
+        yAxis = {
+          label = "y1Axis",
+          scale = "LINEAR"
+        }
+      }
+    },
+    {
+      title = "GPU Utilization (NVML reported)",
+      xyChart = {
+        chartOptions = {
+          mode = "COLOR"
+        },
+        dataSets = [
+          {
+            legendTemplate = "$${metadata.system_labels\\.name} GPU $${metric.labels.gpu_number} Non-Idle",
+            minAlignmentPeriod = "60s",
+            plotType = "LINE",
+            targetAxis = "Y1",
+            timeSeriesQuery = {
+              apiSource = "DEFAULT_CLOUD",
+              timeSeriesFilter = {
+                aggregation = {
+                  alignmentPeriod = "60s",
+                  crossSeriesReducer = "REDUCE_MEAN",
+                  groupByFields = [
+                    "metric.label.\"gpu_number\"",
+                    "metadata.system_labels.\"name\""
+                  ],
+                  perSeriesAligner = "ALIGN_MEAN"
+                },
+                filter = "metric.type=\"agent.googleapis.com/gpu/utilization\" resource.type=\"gce_instance\""
+              }
+            }
+          }
+        ],
+        thresholds = [],
+        timeshiftDuration = "0s",
+        yAxis = {
+          label = "y1Axis",
+          scale = "LINEAR"
+        }
+      }
+    },
+    {
+      title = "GPU Memory Usage (NVML reported)",
+      xyChart = {
+        chartOptions = {
+          mode = "COLOR"
+        },
+        dataSets = [
+          {
+            legendTemplate = "$${metadata.system_labels\\.name} GPU $${metric.labels.gpu_number} $${metric.labels.memory_state}",
+            minAlignmentPeriod = "60s",
+            plotType = "LINE",
+            targetAxis = "Y1",
+            timeSeriesQuery = {
+              apiSource = "DEFAULT_CLOUD",
+              timeSeriesFilter = {
+                aggregation = {
+                  alignmentPeriod = "60s",
+                  crossSeriesReducer = "REDUCE_SUM",
+                  groupByFields = [
+                    "metric.label.\"memory_state\"",
+                    "metric.label.\"gpu_number\"",
+                    "metadata.system_labels.\"name\""
+                  ],
+                  perSeriesAligner = "ALIGN_MEAN"
+                },
+                filter = "metric.type=\"agent.googleapis.com/gpu/memory/bytes_used\" resource.type=\"gce_instance\" metric.label.\"memory_state\"=\"used\""
+              }
+            }
+          }
+        ],
+        thresholds = [],
+        timeshiftDuration = "0s",
+        yAxis = {
+          label = "y1Axis",
+          scale = "LINEAR"
+        }
+      }
+    },
+    {
+      title = "SM Utilization and SM occupancy (DCGM reported)",
+      xyChart = {
+        chartOptions = {
+          mode = "COLOR"
+        },
+        dataSets = [
+          {
+            legendTemplate = "$${metadata.system_labels\\.name} GPU $${metric.labels.gpu_number} SM utilization",
+            minAlignmentPeriod = "60s",
+            plotType = "LINE",
+            targetAxis = "Y1",
+            timeSeriesQuery = {
+              apiSource = "DEFAULT_CLOUD",
+              timeSeriesFilter = {
+                aggregation = {
+                  alignmentPeriod = "60s",
+                  crossSeriesReducer = "REDUCE_SUM",
+                  groupByFields = [
+                    "metric.label.\"gpu_number\"",
+                    "metadata.system_labels.\"name\""
+                  ],
+                  perSeriesAligner = "ALIGN_MEAN"
+                },
+                filter = "metric.type=\"workload.googleapis.com/dcgm.gpu.sm_utilization\" resource.type=\"gce_instance\""
+              }
+            }
+          },
+          {
+            legendTemplate = "$${metadata.system_labels\\.name} GPU $${metric.labels.gpu_number} SM occpancy",
+            minAlignmentPeriod = "60s",
+            plotType = "LINE",
+            targetAxis = "Y1",
+            timeSeriesQuery = {
+              apiSource = "DEFAULT_CLOUD",
+              timeSeriesFilter = {
+                aggregation = {
+                  alignmentPeriod = "60s",
+                  crossSeriesReducer = "REDUCE_SUM",
+                  groupByFields = [
+                    "metric.label.\"gpu_number\"",
+                    "metadata.system_labels.\"name\""
+                  ],
+                  perSeriesAligner = "ALIGN_MEAN"
+                },
+                filter = "metric.type=\"workload.googleapis.com/dcgm.gpu.sm_occupancy\" resource.type=\"gce_instance\""
+              }
+            }
+          }
+        ],
+        thresholds = [],
+        timeshiftDuration = "0s",
+        yAxis = {
+          label = "y1Axis",
+          scale = "LINEAR"
+        }
+      }
+    },
+    {
+      title = "NVLink Traffic Rate (DCGM reported)",
+      xyChart = {
+        chartOptions = {
+          mode = "COLOR"
+        },
+        dataSets = [
+          {
+            plotType = "LINE",
+            targetAxis = "Y1",
+            timeSeriesQuery = {
+              timeSeriesQueryLanguage = <<EOF
+                fetch gce_instance
+                | metric 'workload.googleapis.com/dcgm.gpu.nvlink_traffic_rate'
+                | group_by 1m, [value_nvlink_traffic_rate_mean: mean(cast_units(value.nvlink_traffic_rate, "By/s"))]
+                | every 1m
+                | group_by
+                    [Instance: metadata.system_labels.name, GPU: metric.gpu_number, Direction: metric.direction,
+                     ],
+                    [value_nvlink_traffic_rate_mean_aggregate:
+                       aggregate(value_nvlink_traffic_rate_mean)]
+                EOF
+            }
+          }
+        ],
+        thresholds = [],
+        timeshiftDuration = "0s",
+        yAxis = {
+          label = "y1Axis",
+          scale = "LINEAR"
+        }
+      }
+    },
+    {
+      title = "Pipe Utilization (DCGM reported)",
+      xyChart = {
+        chartOptions = {
+          mode = "COLOR"
+        },
+        dataSets = [
+          {
+            legendTemplate = "$${metadata.system_labels\\.name} GPU $${metric.labels.gpu_number} Pipe $${metric.labels.pipe}",
+            minAlignmentPeriod = "60s",
+            plotType = "LINE",
+            targetAxis = "Y1",
+            timeSeriesQuery = {
+              apiSource = "DEFAULT_CLOUD",
+              timeSeriesFilter = {
+                aggregation = {
+                  alignmentPeriod = "60s",
+                  crossSeriesReducer = "REDUCE_SUM",
+                  groupByFields = [
+                    "metric.label.\"pipe\"",
+                    "metric.label.\"gpu_number\"",
+                    "metadata.system_labels.\"name\""
+                  ],
+                  perSeriesAligner = "ALIGN_MEAN"
+                },
+                filter = "metric.type=\"workload.googleapis.com/dcgm.gpu.pipe_utilization\" resource.type=\"gce_instance\""
+              }
+            }
+          }
+        ],
+        thresholds = [],
+        timeshiftDuration = "0s",
+        yAxis = {
+          label = "y1Axis",
+          scale = "LINEAR"
+        }
+      }
+    },
+    {
+      title = "PCIe Traffic Rate (DCGM reported)",
+      xyChart = {
+        chartOptions = {
+          mode = "COLOR"
+        },
+        dataSets = [
+          {
+            plotType = "LINE",
+            targetAxis = "Y1",
+            timeSeriesQuery = {
+              timeSeriesQueryLanguage = <<EOF
+                fetch gce_instance
+                | metric 'workload.googleapis.com/dcgm.gpu.pcie_traffic_rate'
+                | group_by 1m, [value_pcie_traffic_rate_mean: mean(cast_units(value.pcie_traffic_rate, "By/s"))]
+                | every 1m
+                | group_by
+                    [Instance: metadata.system_labels.name, GPU: metric.gpu_number, Direction: metric.direction,
+                     ],
+                    [value_pcie_traffic_rate_mean_aggregate:
+                       aggregate(value_pcie_traffic_rate_mean)]
+                EOF
+            }
+          }
+        ],
+        thresholds = [],
+        timeshiftDuration = "0s",
+        yAxis = {
+          label = "y1Axis",
+          scale = "LINEAR"
+        }
+      }
+    },
+  ]
+}

--- a/aiinfra-cluster/variables.tf
+++ b/aiinfra-cluster/variables.tf
@@ -151,7 +151,13 @@ variable "orchestrator_type" {
 variable "startup_command" {
   description = "The startup command to be executed when the VM starts up."
   type        = string
-  default = ""
+  default     = ""
+}
+
+variable "disable_ops_agent" {
+  description = ""
+  type        = bool
+  default     = false
 }
 
 variable "local_dir_copy_list" {

--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -17,8 +17,9 @@ steps:
 # Pull the latest version to speed up builds when only later layers have changed.
 # See https://cloud.google.com/build/docs/speeding-up-builds#using_a_cached_docker_image
 - name: 'gcr.io/cloud-builders/docker'
-  entrypoint: 'bash'
-  args: ['-c', 'docker pull us-docker.pkg.dev/${PROJECT_ID}/cluster-provision-dev/cluster-provision-image:latest || exit 0']
+  args: [ 'pull', 'us-docker.pkg.dev/${PROJECT_ID}/cluster-provision-dev/cluster-provision-image:latest' ]
+  allowFailure: true
+
 - name: 'gcr.io/cloud-builders/docker'
   args: [ 'build', '-t', 'us-docker.pkg.dev/${PROJECT_ID}/cluster-provision-dev/cluster-provision-image:latest',
           '--cache-from', 'us-docker.pkg.dev/${PROJECT_ID}/cluster-provision-dev/cluster-provision-image:latest',
@@ -37,5 +38,10 @@ steps:
           '--network=cloudbuild',
           'us-docker.pkg.dev/${PROJECT_ID}/cluster-provision-dev/cluster-provision-image:latest',
           'Validate' ]
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '--tag=test', '--target=test', '.' ]
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'run', 'test' ]
 
 timeout: 900s

--- a/scripts/_env_var_util.sh
+++ b/scripts/_env_var_util.sh
@@ -236,8 +236,13 @@ EOF
         echo "orchestrator_type = \"${ORCHESTRATOR_TYPE,,}\"" >> /usr/primary/tf.auto.tfvars
     fi
 
-    # seting startup command
+    # setting startup command
     if [[ -n "$STARTUP_COMMAND" ]]; then
         echo "startup_command = \"$STARTUP_COMMAND\"" >> /usr/primary/tf.auto.tfvars
+    fi
+
+    # setting disable ops agent
+    if [[ -n "$DISABLE_OPS_AGENT" ]]; then
+      echo "disable_ops_agent = \"${DISABLE_OPS_AGENT,,}\"" >> /usr/primary/tf.auto.tfvars
     fi
 }

--- a/scripts/_terraform_util.sh
+++ b/scripts/_terraform_util.sh
@@ -31,7 +31,7 @@ _terraform_setup() {
     if [ $apply_ret -eq 0 ]; then
         echo "Terraform apply finished successfully."
         _Display_connection_info
-        # setup auto clean is environment variable is set
+        # setup auto clean if environment variable is set
         if [[ -z "$CLEANUP_ON_EXIT" ]]; then
             echo "Cluster will be available after container exits."
         else


### PR DESCRIPTION
- add gpu metrics dashboard (running example [here](https://pantheon.corp.google.com/monitoring/dashboards/builder/5fe35012-9ba5-4e1d-989e-69c7b7168eb1;duration=PT15M;tzId=America%2FLos_Angeles?project=supercomputer-testing))
- install nvidia-dcgm with ops agent (implemented only for Debian, not RedHat)
- retry ops agent install with random-backoff
- add env var `DISABLE_OPS_AGENT` which skips the whole startup script when true