### PR TITLE
Adding metadata to enable fluent bit agent logging for vm instances

### DIFF
--- a/terraform/modules/cluster/mig-with-container/main.tf
+++ b/terraform/modules/cluster/mig-with-container/main.tf
@@ -75,7 +75,11 @@ module "compute_instance_template" {
   guest_accelerator     = var.guest_accelerator
   machine_image         = local.machine_image
   machine_type          = var.machine_type
-  metadata              = { user-data = module.cloudinit.user-data }
+  metadata              = {
+                            user-data = module.cloudinit.user-data
+                            google-logging-use-fluentbit = "true"
+                            google-logging-enabled = "true"
+                          }
   project_id            = var.project_id
   region                = local.region
   resource_prefix       = var.resource_prefix


### PR DESCRIPTION
Follosing Cloud Logging best practices guidelines from here: http://cloud/container-optimized-os/docs/how-to/logging#compatibility_with_gcplogs_driver

this is the terraform bit that needs to be added: http://screen/8o5vjSwff9fV5AP