### PR TITLE
Set LitGPT image paths with env variable and checkout version in bash script

### DIFF
--- a/sample_workloads/lit-gpt-demo/build_and_push_litgpt.sh
+++ b/sample_workloads/lit-gpt-demo/build_and_push_litgpt.sh
@@ -7,8 +7,8 @@ SOME_UUID=$(uuidgen)
 LITGPT_PATH=${LITGPT_PATH:="lit-gpt"}
 echo $LITGPT_PATH
 
-BASE_IMAGE=${BASE_IMAGE:="EITHER ADD HERE OR VIA ENV VAR"}
-FULL_IMAGE=${FULL_IMAGE:="EITHER ADD HERE OR VIA ENV VAR"}
+BASE_IMAGE="$ARTIFACT_REGISTRY/litgpt-base"
+FULL_IMAGE="$ARTIFACT_REGISTRY/litgpt-full"
 
 # Clone LitGPT and checkout a flash-attn enabled commit
 if [ ! -d $LITGPT_PATH ]; then
@@ -16,6 +16,9 @@ if [ ! -d $LITGPT_PATH ]; then
     LITGPT_PATH=lit-gpt
 fi
 
+cd $LITGPT_PATH
+git checkout 841970e4d6a1f5e0458015eaa2810abe642ee989
+cd ..
 cp Dockerfile $LITGPT_PATH/Dockerfile
 
 cd $LITGPT_PATH

--- a/sample_workloads/lit-gpt-demo/build_and_push_litgpt.sh
+++ b/sample_workloads/lit-gpt-demo/build_and_push_litgpt.sh
@@ -7,8 +7,8 @@ SOME_UUID=$(uuidgen)
 LITGPT_PATH=${LITGPT_PATH:="lit-gpt"}
 echo $LITGPT_PATH
 
-BASE_IMAGE="$ARTIFACT_REGISTRY/litgpt-base"
-FULL_IMAGE="$ARTIFACT_REGISTRY/litgpt-full"
+BASE_IMAGE="${ARTIFACT_REGISTRY}/litgpt-base"
+FULL_IMAGE="${ARTIFACT_REGISTRY}/litgpt-full"
 
 # Clone LitGPT and checkout a flash-attn enabled commit
 if [ ! -d $LITGPT_PATH ]; then


### PR DESCRIPTION
Set LitGPT image paths with $ARTIFACT_REGISTRY env variable and set checkout version in build_and_push_litgpt.sh