### PR TITLE
Update setup_and_launch_training.sh

### DIFF
--- a/sample_workloads/lit-gpt-demo/slurm/setup_and_launch_training.sh
+++ b/sample_workloads/lit-gpt-demo/slurm/setup_and_launch_training.sh
@@ -23,31 +23,5 @@ srun --ntasks-per-node=1 \
 srun --ntasks-per-node=1 \
     gcloud auth configure-docker us-central1-docker.pkg.dev
 
-# Start rxdm container
-srun --ntasks-per-node=1 \
-    docker run \
-    --pull=always \
-    --detach \
-    --rm \
-    --name receive-datapath-manager-${SLURM_JOB_ID} \
-    --privileged \
-    --cap-add=NET_ADMIN \
-    --network=host \
-    --gpus all \
-    --volume /var/lib/nvidia/lib64:/usr/local/nvidia/lib64 \
-    --volume ${GPU_NIC_TOPOLOGY_DIR}:${GPU_NIC_TOPOLOGY_DIR} \
-    --volume ${UDS_PATH}:${UDS_PATH} \
-    --env LD_LIBRARY_PATH=/usr/local/nvidia/lib64:${UDS_PATH}:/usr/lib/lib32:/usr/lib/x86_64-linux-gnu/ \
-    --entrypoint /tcpgpudmarxd/build/app/tcpgpudmarxd \
-    us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/tcpgpudmarxd-dev:v2.0.9 \
-    --setup_param "--verbose 128 2 0" \
-    --gpu_nic_preset manual \
-    --gpu_nic_topology ${GPU_NIC_TOPOLOGY} \
-    --gpu_shmem_type fd \
-    --uds_path ${UDS_PATH}
-
 # Launch the litgpt script
 srun -l --ntasks-per-node=1 bash litgpt_container.sh
-
-# Stop rxdm container
-srun --ntasks-per-node=1 docker container stop receive-datapath-manager-${SLURM_JOB_ID}


### PR DESCRIPTION
Remove manual launch and closure of RxDM container since we expect users to use HPC Toolkit to deploy slurm cluster.  Slurm (as provisioned by the HPC toolkit) will launch RxDM  automatically for every job, so we can remove the RxDM operations here.