### PR TITLE
Update v1 schema pause image

### DIFF
--- a/a3/terraform/modules/cluster/gke-beta/scripts/fixup_daemon_set.yaml
+++ b/a3/terraform/modules/cluster/gke-beta/scripts/fixup_daemon_set.yaml
@@ -73,5 +73,5 @@ spec:
             /usr/bin/ctr -n k8s.io images tag $(/usr/bin/cos-extensions list -- --gpu-installer) docker.io/library/cos-nvidia-installer:fixed
           fi
       containers:
-      - image: "gcr.io/google-containers/pause:2.0"
+      - image: "gke.gcr.io/pause:3.8@sha256:880e63f94b145e46f1b1082bb71b85e21f16b99b180b9996407d61240ceb9830"
         name: pause


### PR DESCRIPTION
v1 schema images are deprecated and will no longer be supported in new container runtimes (containerd 2.0).

CC @samuelkarp @SergeyKanzhelev